### PR TITLE
get_transfers support for filtering by min/max heights

### DIFF
--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -201,7 +201,18 @@ using CryptoNote::ISerializer;
   };
 
   struct COMMAND_RPC_GET_TRANSFERS {
-    typedef CryptoNote::EMPTY_STRUCT request;
+    struct request
+    {
+      bool filter_by_height;
+      uint64_t min_height;
+      uint64_t max_height;
+
+      void serialize(ISerializer& s) {
+        KV_MEMBER(filter_by_height);
+        KV_MEMBER(min_height);
+        KV_MEMBER(max_height);
+      }
+    };
 
     struct response {
       std::list<Transfer> transfers;


### PR DESCRIPTION
To test it: 

`curl -X POST http://127.0.0.1:42082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfers","params":{"filter_by_height":true,"min_height":10000,"max_height":15300}}' -H 'Content-Type: application/json'`